### PR TITLE
Support dired / dwim tramp target

### DIFF
--- a/tmtxt-dired-async.el
+++ b/tmtxt-dired-async.el
@@ -42,17 +42,21 @@
   "The arguments for passing into the rsync command")
 
 (defun cpb/maybe-convert-directory-to-rsync-target (directory)
-  "If directory starts with /scp: it is probably a tramp target
-and should be converted to rsync-compatible destination string,
-else we do (shell-quote-argument (expand-file-name directory)) as
-is required for normal local targets acquired with read-file-name
-and dired-dwim-target-directory."
-  (if (string-prefix-p "/scp:" directory)
-      ;; - throw out the initial "/scp:"
+  "If directory starts with /scp: or /ssh: it is probably a tramp
+target and should be converted to rsync-compatible destination
+string, else we do (shell-quote-argument (expand-file-name
+directory)) as is required for normal local targets acquired with
+read-file-name and dired-dwim-target-directory."
+  (if (or (string-prefix-p "/scp:" directory)
+          (string-prefix-p "/ssh:" directory))
+      ;; - throw out the initial "/scp:" or "/ssh:"
       ;; - replace spaces with escaped spaces
       ;; - surround the whole thing with quotes
-      ;; TODO: double-check that target ends with / which in the case of DWIM is what we want
-      (prin1-to-string(replace-regexp-in-string "[[:space:]]" "\\\\\\&" (substring directory 5)))
+      ;; TODO: double-check that target ends with "/""
+      ;; which in the case of DWIM is what we want
+      (prin1-to-string
+       (replace-regexp-in-string "[[:space:]]" "\\\\\\&"
+                                 (substring directory 5)))
     ;; this is what tmtxt-dired-async usually does
     (shell-quote-argument (expand-file-name directory))))
 


### PR DESCRIPTION
If the target directory starts with `/scp:` or `/ssh:`, treat it differently as a
valid rsync target. If not, fall back to the default behaviour.

tda/rsync-* was already great! With this new change, it is also possible to perform any of the rsync actions to a tramp scp target.